### PR TITLE
DE2043 : Don't care if or when unattended-upgrades ran before, only if p...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,6 @@ execute "unattended-upgrade-periodic" do
   command "unattended-upgrade"
   ignore_failure true
   only_if do
-    File.exists?('/var/lib/apt/periodic/update-success-stamp') &&
-    File.mtime('/var/lib/apt/periodic/update-success-stamp') > Time.now - node['unattended_upgrades']['max_seconds_after_aptget_update'].to_i
+    node['unattended_upgrades']['unattended_upgrade_interval'].to_i > 0
   end
 end


### PR DESCRIPTION
...od is configured to run it. If that's the case, kick it off after setting it up
