### PR TITLE
DE2043 : When always_run_unattended_on_exec: true, execute unattended-up...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,4 @@ n[:remove_unused_dependencies] = true
 n[:automatic_reboot] = false
 n[:download_limit] = nil
 n[:max_seconds_after_aptget_update] = 180
+n[:always_run_unattended_on_exec] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,6 +45,7 @@ execute "unattended-upgrade-periodic" do
   command "unattended-upgrade"
   ignore_failure true
   only_if do
+    node['unattended_upgrades']['always_run_unattended_on_exec'] == true ||
     node['unattended_upgrades']['unattended_upgrade_interval'].to_i > 0
   end
 end


### PR DESCRIPTION
...grades even when pod is set to unattended_upgrade_interval 0. This allows us to run the unattended-upgrades without them being scheduled.
